### PR TITLE
Fix sanitize & unserialize failures

### DIFF
--- a/php/class-ajax-api.php
+++ b/php/class-ajax-api.php
@@ -296,7 +296,7 @@ class Ajax_API {
 			'post_type' => Plugin::POST_TYPE,
 			'post_status' => 'publish',
 			'post_title' => isset( $params['name'] ) ? $params['name'] : null,
-			'post_content' => serialize( $params['sanitized_widget_setting'] ), // @todo unfiltered_html problem?
+			'post_content' => base64_encode( serialize( $params['sanitized_widget_setting'] ) ), // using base64_encode to prevent de-serialization errors
 		);
 
 		$r = wp_insert_post( $postarr, true );

--- a/php/class-ajax-api.php
+++ b/php/class-ajax-api.php
@@ -299,7 +299,15 @@ class Ajax_API {
 			'post_content' => base64_encode( serialize( $params['sanitized_widget_setting'] ) ), // using base64_encode to prevent de-serialization errors
 		);
 
+		// Prevent special characters from becoming HTML entities. The VIP Co-Schedule plugin removes this filter.
+		$filter_suspension = new Filter_Suspension( array(
+			array( 'title_save_pre', 'wp_filter_kses' ),
+			array( 'content_save_pre', 'wp_filter_kses' ),
+		) );
+
+		$filter_suspension->start();
 		$r = wp_insert_post( $postarr, true );
+		$filter_suspension->stop();
 
 		if ( is_wp_error( $r ) ) {
 			throw new Exception( $r->get_error_message() );

--- a/php/class-ajax-api.php
+++ b/php/class-ajax-api.php
@@ -27,11 +27,11 @@ class Ajax_API {
 			if ( ! current_user_can( $this->plugin->config['capability'] ) ) {
 				throw new Public_Exception( 'unauthorized', 403 );
 			}
-			if ( empty( $_REQUEST['method'] ) ) {
+			if ( empty( $_REQUEST['method'] ) ) { // wpcs: input var okay
 				throw new Public_Exception( 'bad method param', 400 );
 			}
-			$method = sanitize_key( $_REQUEST['method'] );
-			$params = wp_unslash( $_REQUEST );
+			$method = sanitize_key( $_REQUEST['method'] ); // wpcs: input var okay
+			$params = wp_unslash( $_REQUEST ); // wpcs: input var okay
 
 			$result = null;
 			$params['check_capabilities'] = true;

--- a/php/class-filter-suspension.php
+++ b/php/class-filter-suspension.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace WidgetFavorites;
+
+/**
+ * Remove any present filters before some action, and then restore afterward.
+ */
+class Filter_Suspension {
+
+	/**
+	 * @var array[array(
+	 *     @var string $hook
+	 *     @var string $callback
+	 *     @var string $priority
+	 * )]
+	 */
+	public $suspended_filters = array();
+
+	/**
+	 * @param array[array] $filter_hook_callback_pairs
+	 * @throws Exception
+	 */
+	function __construct( $filter_hook_callback_pairs ) {
+		foreach ( $filter_hook_callback_pairs as $pair ) {
+			if ( ! is_array( $pair ) || 2 !== count( $pair ) ) {
+				throw new Exception( 'Expected array of 2-element arrays to be passed into Filter_Suspension constructor' );
+			}
+			list( $hook, $callback ) = $pair;
+			if ( ! is_callable( $callback, true ) ) {
+				throw new Exception( 'Illegal callback for filter' );
+			}
+			$priority = has_filter( $hook, $callback );
+			if ( false !== $priority ) {
+				$this->suspended_filters[] = compact( 'hook', 'callback', 'priority' );
+			}
+		}
+	}
+
+	/**
+	 * Start suspending filters
+	 */
+	function start() {
+		foreach ( $this->suspended_filters as $suspended_filter ) {
+			remove_filter( $suspended_filter['hook'], $suspended_filter['callback'], $suspended_filter['priority'] );
+		}
+	}
+
+	/**
+	 * Stop suspending filters
+	 */
+	function stop() {
+		foreach ( $this->suspended_filters as $suspended_filter ) {
+			add_filter( $suspended_filter['hook'], $suspended_filter['callback'], $suspended_filter['priority'], PHP_INT_MAX );
+		}
+	}
+
+}

--- a/php/class-filter-suspension.php
+++ b/php/class-filter-suspension.php
@@ -30,6 +30,7 @@ class Filter_Suspension {
 			if ( ! is_callable( $callback, true ) ) {
 				throw new Exception( 'Illegal callback for filter' );
 			}
+			// @todo defer the has_filter() check until actually starting
 			$priority = has_filter( $hook, $callback );
 			if ( false !== $priority ) {
 				$this->suspended_filters[] = compact( 'hook', 'callback', 'priority' );
@@ -44,6 +45,7 @@ class Filter_Suspension {
 		foreach ( $this->suspended_filters as $suspended_filter ) {
 			remove_filter( $suspended_filter['hook'], $suspended_filter['callback'], $suspended_filter['priority'] );
 		}
+		// @todo return the number that were suspended
 	}
 
 	/**
@@ -53,6 +55,9 @@ class Filter_Suspension {
 		foreach ( $this->suspended_filters as $suspended_filter ) {
 			add_filter( $suspended_filter['hook'], $suspended_filter['callback'], $suspended_filter['priority'], PHP_INT_MAX );
 		}
+		// @todo return the number that were restored
 	}
+
+	// @todo add function for wrapping a function call with start/stop
 
 }

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -285,7 +285,12 @@ class Plugin {
 
 		$sanitized_widget_setting = array();
 		if ( $post->post_content ) {
-			$sanitized_widget_setting = unserialize( $post->post_content );
+			$serialized = $post->post_content;
+			$is_base64_encoded = ( ! is_serialized( $serialized ) ); // as of 0.1.2, we base64-encode the serialized data to prevent unserialization errors
+			if ( $is_base64_encoded ) {
+				$serialized = base64_decode( $serialized );
+			}
+			$sanitized_widget_setting = unserialize( $serialized );
 		}
 		$sanitized_widget_setting = $this->get_customize_manager()->widgets->sanitize_widget_js_instance( $sanitized_widget_setting );
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ Store revisions of widget instances for re-use.
 **Stable tag:** trunk (master)  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
+[![Build Status](https://travis-ci.org/xwp/wp-widget-favorites.png?branch=master)](https://travis-ci.org/xwp/wp-widget-favorites) 
+
 ## Description ##
 
 Sometimes you have a certain widget configuration that you need to use over-and-over again.

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,6 @@ Store revisions of widget instances for re-use.
 **Stable tag:** trunk (master)  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
-[![Build Status](https://travis-ci.org/xwp/wp-widget-favorites.png?branch=master)](https://travis-ci.org/xwp/wp-widget-favorites) 
-
 ## Description ##
 
 Sometimes you have a certain widget configuration that you need to use over-and-over again.

--- a/tests/test-class-filter-suspension.php
+++ b/tests/test-class-filter-suspension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WidgetFavorites;
+
+class ClassFilterSuspensionTest extends \WP_UnitTestCase {
+
+	function test_all() {
+		add_filter( 'foo', 'strtoupper' );
+		add_filter( 'bar', 'strrev', 20 );
+
+		$foo_value = 'value1';
+		$bar_value = 'value2';
+
+		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
+		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
+
+		$instance = new Filter_Suspension( array(
+			array( 'foo', 'strtoupper' ),
+			array( 'bar', 'strrev' ),
+		) );
+
+		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
+		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
+
+		$instance->start();
+
+		$this->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
+		$this->assertEquals( $bar_value, apply_filters( 'bar', $bar_value ) );
+
+		$instance->stop();
+
+		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
+		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
+	}
+
+}

--- a/tests/test-class-filter-suspension.php
+++ b/tests/test-class-filter-suspension.php
@@ -7,16 +7,21 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 	function test_all() {
 		add_filter( 'foo', 'strtoupper' );
 		add_filter( 'bar', 'strrev', 20 );
+		add_filter( 'baz', 'strtolower', 30 );
 
 		$foo_value = 'value1';
 		$bar_value = 'value2';
 
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
+		$this->assertEquals( 10, has_filter( 'foo', 'strtoupper' ) );
+		$this->assertEquals( 20, has_filter( 'bar', 'strrev' ) );
+		$this->assertEquals( 30, has_filter( 'baz', 'strtolower' ) );
 
 		$instance = new Filter_Suspension( array(
 			array( 'foo', 'strtoupper' ),
 			array( 'bar', 'strrev' ),
+			array( 'baz', 'strtolower' ),
 		) );
 
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
@@ -26,11 +31,17 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 
 		$this->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( $bar_value, apply_filters( 'bar', $bar_value ) );
+		$this->assertEquals( false, has_filter( 'foo', 'strtoupper' ) );
+		$this->assertEquals( false, has_filter( 'bar', 'strrev' ) );
+		$this->assertEquals( false, has_filter( 'baz', 'strtolower' ) );
 
 		$instance->stop();
 
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
+		$this->assertEquals( 10, has_filter( 'foo', 'strtoupper' ) );
+		$this->assertEquals( 20, has_filter( 'bar', 'strrev' ) );
+		$this->assertEquals( 30, has_filter( 'baz', 'strtolower' ) );
 	}
 
 }

--- a/tests/test-class-filter-suspension.php
+++ b/tests/test-class-filter-suspension.php
@@ -22,12 +22,14 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 			array( 'foo', 'strtoupper' ),
 			array( 'bar', 'strrev' ),
 			array( 'baz', 'strtolower' ),
+			array( 'quux', 'strip_tags' ),
 		) );
 
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
 
-		$instance->start();
+		$removed = $instance->start();
+		$this->assertEquals( 3, $removed );
 
 		$this->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( $bar_value, apply_filters( 'bar', $bar_value ) );
@@ -35,13 +37,32 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 		$this->assertEquals( false, has_filter( 'bar', 'strrev' ) );
 		$this->assertEquals( false, has_filter( 'baz', 'strtolower' ) );
 
-		$instance->stop();
+		$added = $instance->stop();
+		$this->assertEquals( 3, $added );
 
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
 		$this->assertEquals( strrev( $bar_value ), apply_filters( 'bar', $bar_value ) );
 		$this->assertEquals( 10, has_filter( 'foo', 'strtoupper' ) );
 		$this->assertEquals( 20, has_filter( 'bar', 'strrev' ) );
 		$this->assertEquals( 30, has_filter( 'baz', 'strtolower' ) );
+	}
+
+	function test_run() {
+
+		add_filter( 'foo', 'strtoupper' );
+		$foo_value = 'value1';
+
+		$instance = new Filter_Suspension( array(
+			array( 'foo', 'strtoupper' ),
+		) );
+		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
+
+		$retval = $instance->run( function () use ( $foo_value ) {
+			$this->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
+			return 'bard';
+		} );
+		$this->assertEquals( 'bard', $retval );
+
 	}
 
 }

--- a/tests/test-class-filter-suspension.php
+++ b/tests/test-class-filter-suspension.php
@@ -48,6 +48,7 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 	}
 
 	function test_run() {
+		$test = $this; // for PHP 5.3 closures
 
 		add_filter( 'foo', 'strtoupper' );
 		$foo_value = 'value1';
@@ -57,8 +58,8 @@ class ClassFilterSuspensionTest extends \WP_UnitTestCase {
 		) );
 		$this->assertEquals( strtoupper( $foo_value ), apply_filters( 'foo', $foo_value ) );
 
-		$retval = $instance->run( function () use ( $foo_value ) {
-			$this->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
+		$retval = $instance->run( function () use ( $foo_value, $test ) {
+			$test->assertEquals( $foo_value, apply_filters( 'foo', $foo_value ) );
 			return 'bard';
 		} );
 		$this->assertEquals( 'bard', $retval );


### PR DESCRIPTION
On VIP, it was discovered that `wp_filter_kses` was being applied to the `title_save_pre` filter, causing `&` to be stored as `&amp;` in the favorited widget's name. So this PR removes that filter while inserting the post via a new `Filter_Suspension` class.

Additionally, the `content_save_pre` filter and other filters related to saving and fetching the `post_content` was causing the serialized PHP widget instance to fail to be unserialized. So we get around this by base64-encoding the serialized widget instance, which is what `WP_Customize_Widgets` also does when passing around widget instance settings.
